### PR TITLE
feat: add social-messages event stream details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 node_modules
 dist
+.env

--- a/README.md
+++ b/README.md
@@ -25,7 +25,16 @@ Startup local Tigris development environment listening on port 8081:
 docker run -d -p 8081:8081 tigrisdata/tigris-local:latest
 ```
 
-## Compile and start the application
+## Configure, compile and start the application
+
+Create a `.env` file in the root of the application and add Tigris Data application client ID and client secret configuration.
+
+```
+TIGRIS_CLIENT_ID='your-tigris-data-app-client-id`
+TIGRIS_CLIENT_SECRET='your-tigris-data-app-client-secret`
+```
+
+Compile and start the application:
 
 ```shell
 npm run build && npm run start

--- a/README.md
+++ b/README.md
@@ -35,12 +35,30 @@ npm run build && npm run start
 
 ### Event Streaming
 
-Run the following command in a new terminal window to watch the events stream in
+Run the following command in a new terminal window to watch user events stream in
 real-time:
 
 ```shell
 curl -N -X POST localhost:8080/users/subscribe
 ```
+
+Run the following command in a new terminal window to watch social message events stream in
+real-time:
+
+```shell
+curl -N -X POST localhost:8080/social-messages/subscribe
+```
+
+Run the following command in a new terminal to publish social message events:
+
+```shell
+curl localhost:8080/social-messages/publish \
+    -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"nickName":"John","message":"Real-time event streams with Tigris Data!"}'
+```
+
+You can also try out the publish and subscribe functionality in the browser by visiting http://localhost:8080.
 
 ### CRUD operations
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache 2.0",
       "dependencies": {
         "@tigrisdata/core": "^1.0.0-beta.6",
-        "dotenv": "^16.0.1",
+        "dotenv": "^16.0.3",
         "express": "^4.18.1"
       },
       "devDependencies": {
@@ -1141,9 +1141,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.0.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
-      "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
       "engines": {
         "node": ">=12"
       }
@@ -4346,9 +4346,9 @@
       }
     },
     "dotenv": {
-      "version": "16.0.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
-      "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA=="
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "ee-first": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "homepage": "https://github.com/tigrisdata/tigris-starter-ts#readme",
   "dependencies": {
     "@tigrisdata/core": "^1.0.0-beta.6",
-    "dotenv": "^16.0.1",
+    "dotenv": "^16.0.3",
     "express": "^4.18.1"
   },
   "devDependencies": {

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
+    />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Tigris real-time example</title>
+  </head>
+  <body>
+    <label for="nickName">Nick name</label>
+    <input type="text" placeholder="Nick name" id="nickName" />
+    <label for="message">Message</label>
+    <input type="text" placeholder="Message" id="message" />
+    <button onclick="addNewMessage()">Send message</button>
+    <table class="messages">
+      <thead>
+        <tr>
+          <th>NickName</th>
+          <th>Message</th>
+        </tr>
+      </thead>
+      <tbody id="messages-table"></tbody>
+    </table>
+    <script>
+      // publish new messages
+      function addNewMessage() {
+        const nickNameInput = document.getElementById("nickName");
+        const messageInput = document.getElementById("message");
+        const nickName = nickNameInput.value;
+        const message = messageInput.value;
+        nickNameInput.value = "";
+        messageInput.value = "";
+        fetch(`/social-messages/publish`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({nickName, message})
+        });
+      }
+
+      // listen for new messages
+      fetch(`/social-messages/subscribe`, {
+        method: "POST",
+      }).then(async (response) => {
+        const streamReader = response.body.getReader();
+        while (true) {
+          const { value, done } = await streamReader.read();
+          if (done) break;
+          const string = new TextDecoder().decode(value);
+          const strLines = string.split("\n");
+          for (let i in strLines) {
+            if (strLines[i].length === 0) continue;
+            let message = JSON.parse(strLines[i]);
+            const newMessageRow = document.createElement("tr");
+            newMessageRow.innerHTML = `<td>${message.nickName}</td><td>${message.message}</td>`;
+            document
+              .getElementById("messages-table")
+              .appendChild(newMessageRow);
+          }
+        }
+      }).catch(error => {
+        console.error(error)
+      });
+    </script>
+  </body>
+</html>

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,9 @@ import { ProductController } from "./controllers/product-controller";
 import { OrderController } from "./controllers/order-controller";
 import { SocialMessageController } from "./controllers/social-message-controller";
 
+import dotenv from 'dotenv';
+dotenv.config();
+
 export class App {
   private readonly app: express.Application;
   private readonly port: string | number;
@@ -22,27 +25,25 @@ export class App {
     this.port = 8080;
     this.dbName = "tigris_starter_ts";
 
-    /*
-
-    // For the Tigris preview environment use following initialization instead.
+    // For the Tigris preview environment use the following initialization.
     this.tigris = new Tigris({
       serverUrl: "api.preview.tigrisdata.cloud",
-      clientId: "your-tigris-client-id",
-      clientSecret: "your-tigris-client-secret"
+      clientId: process.env.TIGRIS_CLIENT_ID,
+      clientSecret: process.env.TIGRIS_CLIENT_SECRET,
     });
 
-    */
-
-    this.tigris = new Tigris({
-      serverUrl: "localhost:8081",
-      insecureChannel: true,
-    });
+    // For the Tigris local environment use the following initialization.
+    // this.tigris = new Tigris({
+    //   serverUrl: "localhost:8081",
+    //   insecureChannel: true,
+    // });
 
     this.setup();
   }
 
   public async setup() {
     this.app.use(express.json());
+    this.app.use(express.static("public"));
     await this.initializeTigris();
     await this.setupControllers();
   }
@@ -58,10 +59,7 @@ export class App {
       this.db.createOrUpdateCollection<Product>("products", productSchema),
       this.db.createOrUpdateCollection<Order>("orders", orderSchema),
       this.db.createOrUpdateTopic<UserEvent>("user_events", userEventSchema),
-      this.db.createOrUpdateTopic<SocialMessage>(
-        "social_messages",
-        socialMessageSchema
-      ),
+      this.db.createOrUpdateTopic<SocialMessage>("social_messages", socialMessageSchema),
     ]);
   }
 


### PR DESCRIPTION
Social message event streams were already within a controller. This PR adds:

- details about social-messages event streaming to the README
- moves client ID and client secret config to a `.env` file
- adds an event streaming demo based on https://blog.tigrisdata.com/http2-websockets-future-of-real-time

Note: I'm not sure if it is correct to have a (basic) UI demo in this app or if it should be served from the root of the server.